### PR TITLE
fix uppercasing of context-macros

### DIFF
--- a/zhostupdater.py
+++ b/zhostupdater.py
@@ -172,7 +172,11 @@ if host_name:
                       if '=' in field:
                              # Create macro object with proper value
                              field=field.split('=')
-                             name=unicode("{$" + field[0].upper() + "}")
+                             if ':' in field[0]:
+                                   # context-macro contains ':', only uppercase macro name
+                                   name=unicode("{$" + field[0].split(':')[0].upper() + ':' + field[0].split(':')[1] + "}")
+                             else:
+                                   name=unicode("{$" + field[0].upper() + "}")
                              value=unicode(field[1])
                              macro={"macro":name,"value":value}
                              zbxmac.append(macro)


### PR DESCRIPTION
When uppercasing the whole macro name, in many cases context macros will not work. Consider "`{DISK_SPACE_WARN:/storage/volume}`", which is not the same as "`{DISK_SPACE_WARN:/STORAGE/VOLUME}`".

This fix changes only the part on the left side of the colon.